### PR TITLE
fixing two broken links to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 * If you would like to contribute through development, you can fork this repo, make your changes and submit a pull request. If you contribute regularly, you can request collaborator access from @wspiro
 * If you would like to contribute through testing - please [install the beta version of the chrome extension](https://github.com/williamspiro/HubSpot-Developer-Extension/wiki/How-to-use-the-Beta-version-of-the-extension). Then Join the slack channel and provide feedback, let us know if you find a bug or have an idea.
 * If you would like to contribute through taking screenshots for the web store - make sure you're using the latest version of the stable version of the extension and post issues with your screenshots. You could also be pre-emptive and submit screenshots taken from the beta version, allowing us to have up-to-date screenshots by the time that goes live.
-* [Don't be a richard, no one likes a richard, sorry Richard.](https://github.com/williamspiro/HubSpot-Developer-Extension/blob/contributors-update/CODE_OF_CONDUCT.md)
+* [Don't be a richard, no one likes a richard, sorry Richard.](https://github.com/TheWebTech/HubSpot-Developer-Extension/blob/master/CODE_OF_CONDUCT.md)
 
 ## Making changes to the extension
 If you would like to make changes, I suggest reviewing the issues, and see if a discussion related to the feature or bug you want to work on exists. There may already be a discussion about the best way to implement something.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Firefox cannot run the extension. We do however want to support Firefox but need
 ## How to Contribute:
 
 1. [Read this first!](https://github.com/williamspiro/HubSpot-Developer-Extension/blob/master/CONTRIBUTING.md)
-2. [Don't be a richard, no one likes a richard. Sorry Richard.](https://github.com/williamspiro/HubSpot-Developer-Extension/blob/contributors-update/CODE_OF_CONDUCT.md)
+2. [Don't be a richard, no one likes a richard. Sorry Richard.](https://github.com/TheWebTech/HubSpot-Developer-Extension/blob/master/CODE_OF_CONDUCT.md)
 3. [We denote easy/small issues that are good for beginners. but feel free to tackle any you see in issues or add a feature you want](https://github.com/williamspiro/HubSpot-Developer-Extension/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 4. Speak another language? [help add or improve translations for that language!](https://github.com/williamspiro/HubSpot-Developer-Extension/wiki/How-to-add-support-for-a-new-language-or-improve-existing-translations)
 5. Test your own branch or someone elses. [how to test](https://github.com/williamspiro/HubSpot-Developer-Extension/wiki/How-to-test-changes-you've-made-to-the-extension) 


### PR DESCRIPTION
Sorry the checklist urges me not to pull request to master, but I cannot find a suitable branch to merge, and there does not appear to be a "Develop" fallback branch (https://cdn2.hubspot.net/hubfs/3967897/2019-06-04%2000_35_06-Comparing%20TheWebTech_master...viktorbrech_master%20%C2%B7%20TheWebTech_HubSpot-Developer-.png ). Apologies!

The only edit here is to the URL of the "code of conduct" in two markup files. Those links are currently 404ing. While I don't know what a richard is, I doubt it is is intentional, so I substituted a valid URL in both places.
